### PR TITLE
Store user info docs on a (private) path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,9 @@
 
 Database sessions are not implemented, this adapter relies on usage of JSON Web Tokens for stateless session management.
 
-### Recommendations
+### Privacy and user information
 
-you must make the dataset private otherwise the data of your users will be public for everyone
-
-```sh
-sanity dataset visibility set <datasetName> private
-```
+Storing people's user credentials is always a big responsibility. Make sure you understand the risks and inform your users accordingly. This adapter store the user information with [the `_id` on the `user.` path](https://www.sanity.io/docs/ids#fdc25ada5db2). In other words, these documents can't be queried without authentication, even if your dataset is set to be public. That also means that these documents are available for everyone that's part of your Sanity project.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@sanity/client": "^2.8.0",
+    "@sanity/uuid": "^3.0.1",
     "argon2": "^0.27.2",
     "axios": "^0.21.1",
     "groq": "^2.2.6",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -7,6 +7,8 @@ import {
 } from './queries';
 import LRU from 'lru-cache';
 import { SanityClient } from '@sanity/client';
+import {uuid} from '@sanity/uuid'
+
 
 type Options = {
   client: SanityClient;
@@ -21,6 +23,7 @@ export const SanityAdapter = ({ client }: Options) => {
   const getAdapter = async () => {
     async function createUser(profile: Profile): Promise<User> {
       const user = await client.create({
+        _id: `user.${uuid()}`,
         _type: 'user',
         email: profile.email,
         name: profile.name,

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -3,7 +3,7 @@ import { SanityClient } from '@sanity/client';
 import { getUserByEmailQuery } from './queries';
 import argon2 from 'argon2';
 import { IncomingMessage, ServerResponse } from 'node:http';
-
+import {uuid} from '@sanity/uuid'
 interface Options {
   client: SanityClient;
 }
@@ -31,6 +31,7 @@ export const signUpHandler = async ({ req, client, res }: Handler) => {
   }
 
   const newUser = await client.create({
+    _id: `user.${uuid()}`,
     _type: 'user',
     email,
     password: await argon2.hash(password),

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,14 @@
   resolved "https://registry.yarnpkg.com/@sanity/timed-out/-/timed-out-4.0.2.tgz#c9f61f9a1609baa1eb3e4235a24ea2a775022cdf"
   integrity sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==
 
+"@sanity/uuid@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sanity/uuid/-/uuid-3.0.1.tgz#e688f5a1f909b3f2dea6f8d0ac922b64bb910234"
+  integrity sha512-cfWq8l/M6TiDYlp2VYJR2MNdrl0u/lkYWjJVflLHsiGjG8SZKbbRSsfG1fn7rSvdZg+o/xfBlKCfhFTtEiXKJg==
+  dependencies:
+    "@types/uuid" "^8.0.0"
+    uuid "^8.0.0"
+
 "@sqltools/formatter@^1.2.2":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
@@ -92,6 +100,11 @@
   version "14.14.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
+
+"@types/uuid@^8.0.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/zen-observable@^0.8.2":
   version "0.8.2"
@@ -1200,6 +1213,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
Hi!

Thanks for putting together this adapter! Noticed that you recommended setting the dataset to private in order to make the user documents not public. This PR introduces another approach where dataset visibility doesn't matter because documents stored on a path won't be accessible through the public API (for example `user.214d0e86-417d-48fb-9d89-fbe3d7da87d9`).

This means that developers can leave their datasets public and get access to query CDNs and all that good stuff, without leaking the user documents. 