### PR TITLE
Fix: Remove duplicated signUpHandler

### DIFF
--- a/examples/full-example/src/pages/api/sanity/signUp.ts
+++ b/examples/full-example/src/pages/api/sanity/signUp.ts
@@ -1,4 +1,0 @@
-import { signUpHandler } from 'next-auth-sanity';
-import { client } from '@/lib/sanity';
-
-export default signUpHandler(client);


### PR DESCRIPTION
Hey @fedeya 👋🏼 

Thanks a lot for this useful plugin. So far so good except for the build today. 

## Summary
I was facing a few issues related to `@argon2` and `@mapbox/node-pre-gyp`. It was running on the browser side. But I had no idea why.

## Investigation

I have mainly followed the example folder and by giving a second check I might have found a duplication which can cause some troubles.

Starting NextJS 13 all things related to the server should be within `/app` folder instead. https://nextjs.org/docs/messages/prerender-error

<img width="500" alt="Screenshot 2024-04-17 at 22 53 13" src="https://github.com/fedeya/next-auth-sanity/assets/28066214/b1bb84c5-b27f-405a-8dc4-2ec227cc006b">

## Answer

So I have basically removed `examples/full-example/src/pages/api/sanity/signUp.ts` because `examples/full-example/src/app/api/sanity/signUp.ts` is already there to cover the `signUpHandler` export.

Also, I'd recommend adding `"next": ">= 13.0.0"` in `peerDependencies` to be sure everyone is targeting NextJS 13 at least. What do you think ?


## Issues maybe related

It can potentially solve a few issues:

- https://github.com/fedeya/next-auth-sanity/issues/70
- https://github.com/fedeya/next-auth-sanity/issues/69
- https://github.com/fedeya/next-auth-sanity/issues/35